### PR TITLE
feat(message-handler): reply inline to messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.1.700
+dotnet: 3.1
 install:
   - dotnet restore src/GlobalX.ChatBots.WebexTeams.sln
   - dotnet build src/GlobalX.ChatBots.WebexTeams/GlobalX.ChatBots.WebexTeams.csproj

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="GlobalX.ChatBots.Core" Version="1.3.0" />
+    <PackageReference Include="GlobalX.ChatBots.Core" Version="1.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/GlobalX.ChatBots.WebexTeams.Tests.csproj
@@ -10,17 +10,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="GlobalX.ChatBots.Core" Version="1.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/Services/HttpClientProxyTests.cs
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/Services/HttpClientProxyTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using GlobalX.ChatBots.WebexTeams.Configuration;
+using GlobalX.ChatBots.WebexTeams.Models;
 using GlobalX.ChatBots.WebexTeams.Services;
 using GlobalX.ChatBots.WebexTeams.Tests.TestServices;
 using Microsoft.Extensions.Options;
@@ -54,13 +55,23 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.Services
         [Fact]
         public void BadRequestPostRequestShouldThrowInvalidParentException()
         {
-
+            this.Given(x => GivenAPath())
+                .And(x => GivenABody())
+                .And(x => GivenResponseIsBadRequest())
+                .When(x => WhenPostAsyncIsCalled())
+                .Then(x => ThenInvalidParentExceptionShouldBeThrown())
+                .BDDfy();
         }
 
         [Fact]
         public void ErrorInPostRequestShouldThrowHttpRequestException()
         {
-
+            this.Given(x => GivenAPath())
+                .And(x => GivenABody())
+                .And(x => GivenResponseIsUnsuccessful())
+                .When(x => WhenPostAsyncIsCalled())
+                .Then(x => ThenHttpRequestExceptionShouldBeThrown())
+                .BDDfy();
         }
 
         private void GivenAPath()
@@ -78,6 +89,16 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.Services
             _messageHandler.SetResponse(HttpStatusCode.OK, "OK");
         }
 
+        private void GivenResponseIsBadRequest()
+        {
+            _messageHandler.SetResponse(HttpStatusCode.BadRequest, "Bad Request");
+        }
+
+        private void GivenResponseIsUnsuccessful()
+        {
+            _messageHandler.SetResponse(HttpStatusCode.InternalServerError, "Internal Server Error");
+        }
+
         private async void WhenPostAsyncIsCalled()
         {
             _exception = await Record.ExceptionAsync(async () => _response = await _subject.PostAsync(_path, _body));
@@ -86,6 +107,18 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.Services
         private void ThenNoExceptionShouldBeThrown()
         {
             _exception.ShouldBeNull();
+        }
+
+        private void ThenInvalidParentExceptionShouldBeThrown()
+        {
+            _exception.ShouldNotBeNull();
+            _exception.ShouldBeOfType<InvalidParentException>();
+        }
+
+        private void ThenHttpRequestExceptionShouldBeThrown()
+        {
+            _exception.ShouldNotBeNull();
+            _exception.ShouldBeOfType<HttpRequestException>();
         }
 
         private void ThenHttpClientShouldReceiveARequest()

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/Services/HttpClientProxyTests.cs
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/Services/HttpClientProxyTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using GlobalX.ChatBots.WebexTeams.Configuration;
+using GlobalX.ChatBots.WebexTeams.Services;
+using GlobalX.ChatBots.WebexTeams.Tests.TestServices;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace GlobalX.ChatBots.WebexTeams.Tests.Services
+{
+    public class HttpClientProxyTests
+    {
+        private readonly HttpClient _httpClient;
+        private readonly MockHttpMessageHandler _messageHandler;
+        private IHttpClientProxy _subject;
+
+        private string _path;
+        private string _body;
+
+        private Exception _exception;
+        private string _response;
+
+        public HttpClientProxyTests()
+        {
+            _messageHandler = new MockHttpMessageHandler();
+            _httpClient = new HttpClient(_messageHandler);
+            var settingsContainer = Substitute.For<IOptions<WebexTeamsSettings>>();
+            var settings = new WebexTeamsSettings
+            {
+                BotAuthToken = "botAuthToken",
+                WebexTeamsApiUrl = "https://localhost:1234"
+            };
+            settingsContainer.Value.Returns(settings);
+            _subject = new HttpClientProxy(_httpClient, settingsContainer);
+        }
+
+        [Fact]
+        public void PostRequestShouldSendRequest()
+        {
+            this.Given(x => GivenAPath())
+                .And(x => GivenABody())
+                .And(x => GivenResponseIsValid())
+                .When(x => WhenPostAsyncIsCalled())
+                .Then(x => ThenNoExceptionShouldBeThrown())
+                .And(x => ThenHttpClientShouldReceiveARequest())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void BadRequestPostRequestShouldThrowInvalidParentException()
+        {
+
+        }
+
+        [Fact]
+        public void ErrorInPostRequestShouldThrowHttpRequestException()
+        {
+
+        }
+
+        private void GivenAPath()
+        {
+            _path = "/api/endpoint";
+        }
+
+        private void GivenABody()
+        {
+            _body = "{\"key\": \"value\"}";
+        }
+
+        private void GivenResponseIsValid()
+        {
+            _messageHandler.SetResponse(HttpStatusCode.OK, "OK");
+        }
+
+        private async void WhenPostAsyncIsCalled()
+        {
+            _exception = await Record.ExceptionAsync(async () => _response = await _subject.PostAsync(_path, _body));
+        }
+
+        private void ThenNoExceptionShouldBeThrown()
+        {
+            _exception.ShouldBeNull();
+        }
+
+        private void ThenHttpClientShouldReceiveARequest()
+        {
+            _messageHandler.Inputs.Count.ShouldBe(1);
+            _messageHandler.Inputs[0].ShouldNotBeNull();
+        }
+    }
+}

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/TestData/WebexTeamsMessageHandlerTestData.cs
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/TestData/WebexTeamsMessageHandlerTestData.cs
@@ -205,5 +205,23 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.TestData
                 }
             };
         }
+
+        public static IEnumerable<object[]> BadParentMessageTestData()
+        {
+            yield return new object[]
+            {
+                new GlobalXMessage
+                {
+                    ParentId = "badParentId",
+                    Text = "test message"
+                },
+                new WebexTeamsMessage
+                {
+                    Text = "test message",
+                    ParentId = "goodParentId",
+                    PersonId = "personId"
+                }
+            };
+        }
     }
 }

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/TestServices/MockHttpMessageHandler.cs
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/TestServices/MockHttpMessageHandler.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GlobalX.ChatBots.WebexTeams.Tests.TestServices
+{
+    public class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private string _response;
+        private HttpStatusCode _statusCode;
+
+        public List<string> Inputs { get; private set; }
+
+        public MockHttpMessageHandler()
+        {
+            _response = null;
+            _statusCode = HttpStatusCode.NotImplemented;
+
+            Inputs = new List<string>();
+        }
+
+        public void SetResponse(HttpStatusCode statusCode)
+        {
+            SetResponse(statusCode, _response);
+        }
+
+        public void SetResponse(HttpStatusCode statusCode, string response)
+        {
+            _statusCode = statusCode;
+            _response = response;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Inputs.Add(await request.Content.ReadAsStringAsync());
+
+            return new HttpResponseMessage
+            {
+                StatusCode = _statusCode,
+                Content = new StringContent(_response)
+            };
+        }
+    }
+}

--- a/src/GlobalX.ChatBots.WebexTeams/GlobalX.ChatBots.WebexTeams.csproj
+++ b/src/GlobalX.ChatBots.WebexTeams/GlobalX.ChatBots.WebexTeams.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <DebugType>Full</DebugType>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GlobalX.ChatBots.WebexTeams/GlobalX.ChatBots.WebexTeams.csproj
+++ b/src/GlobalX.ChatBots.WebexTeams/GlobalX.ChatBots.WebexTeams.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="GlobalX.ChatBots.Core" Version="1.3.0" />
+    <PackageReference Include="GlobalX.ChatBots.Core" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />

--- a/src/GlobalX.ChatBots.WebexTeams/GlobalX.ChatBots.WebexTeams.csproj
+++ b/src/GlobalX.ChatBots.WebexTeams/GlobalX.ChatBots.WebexTeams.csproj
@@ -9,10 +9,10 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="GlobalX.ChatBots.Core" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>

--- a/src/GlobalX.ChatBots.WebexTeams/Models/CreateMessageRequest.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Models/CreateMessageRequest.cs
@@ -5,6 +5,7 @@ namespace GlobalX.ChatBots.WebexTeams.Models {
         public string ToPersonEmail { get; set; }
         public string Text { get; set; }
         public string Markdown { get; set; }
+        public string ParentId { get; set; }
         public string[] Files { get; set; }
     }
 }

--- a/src/GlobalX.ChatBots.WebexTeams/Models/InvalidParentException.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Models/InvalidParentException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace GlobalX.ChatBots.WebexTeams.Models
+{
+    internal class InvalidParentException : Exception
+    {
+    }
+}

--- a/src/GlobalX.ChatBots.WebexTeams/Models/Message.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Models/Message.cs
@@ -7,6 +7,7 @@ namespace GlobalX.ChatBots.WebexTeams.Models {
         public string RoomType { get; set; }
         public string ToPersonId { get; set; }
         public string ToPersonEmail { get; set; }
+        public string ParentId { get; set; }
         public string Text { get; set; }
         public string Markdown { get; set; }
         public string Html { get; set; }

--- a/src/GlobalX.ChatBots.WebexTeams/Services/HttpClientProxy.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Services/HttpClientProxy.cs
@@ -47,6 +47,7 @@ namespace GlobalX.ChatBots.WebexTeams.Services
                 Content = body != null ? new StringContent(body, Encoding.UTF8, "application/json") : null
             };
 
+
             var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.BadRequest)

--- a/src/GlobalX.ChatBots.WebexTeams/Services/HttpClientProxy.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Services/HttpClientProxy.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using GlobalX.ChatBots.WebexTeams.Configuration;
+using GlobalX.ChatBots.WebexTeams.Models;
 using Microsoft.Extensions.Options;
 
 namespace GlobalX.ChatBots.WebexTeams.Services
@@ -44,7 +46,14 @@ namespace GlobalX.ChatBots.WebexTeams.Services
                 RequestUri = new Uri($"{_settings.WebexTeamsApiUrl}{path}"),
                 Content = body != null ? new StringContent(body, Encoding.UTF8, "application/json") : null
             };
+
             var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.BadRequest)
+            {
+                throw new InvalidParentException();
+            }
+
             response.EnsureSuccessStatusCode();
 
             var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageHandler.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageHandler.cs
@@ -1,7 +1,10 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 using GlobalX.ChatBots.Core.Messages;
-using GlobalX.ChatBots.Core.People;
 using GlobalX.ChatBots.WebexTeams.Mappers;
+using GlobalX.ChatBots.WebexTeams.Models;
+using Message = GlobalX.ChatBots.Core.Messages.Message;
+using Person = GlobalX.ChatBots.Core.People.Person;
 
 namespace GlobalX.ChatBots.WebexTeams.Services
 {
@@ -22,7 +25,32 @@ namespace GlobalX.ChatBots.WebexTeams.Services
         public async Task<Message> SendMessageAsync(Message message)
         {
             var request = _messageParser.ParseCreateMessageRequest(message);
+
+            Models.Message result;
+            try
+            {
+                result = await _apiService.SendMessageAsync(request).ConfigureAwait(false);
+            }
+            catch (InvalidParentException)
+            {
+                result = await ResendMessageWithRootParentId(message);
+            }
+
+            return await GetSentMessageWithSender(result);
+        }
+
+        private async Task<Models.Message> ResendMessageWithRootParentId(Message message)
+        {
+            var realParent = await _apiService.GetMessageAsync(message.ParentId);
+            message.ParentId = realParent.Id;
+
+            var request = _messageParser.ParseCreateMessageRequest(message);
             var result = await _apiService.SendMessageAsync(request).ConfigureAwait(false);
+            return result;
+        }
+
+        private async Task<Message> GetSentMessageWithSender(Models.Message result)
+        {
             var mapped = _messageParser.ParseMessage(result);
             var sender = await _apiService.GetPersonAsync(result.PersonId);
             var mappedSender = _mapper.Map<Person>(sender);

--- a/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageHandler.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageHandler.cs
@@ -1,4 +1,3 @@
-using System.Net.Http;
 using System.Threading.Tasks;
 using GlobalX.ChatBots.Core.Messages;
 using GlobalX.ChatBots.WebexTeams.Mappers;

--- a/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageParser.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageParser.cs
@@ -59,7 +59,11 @@ namespace GlobalX.ChatBots.WebexTeams.Services
 
         public CreateMessageRequest ParseCreateMessageRequest(GlobalXMessage message)
         {
-            var request = new CreateMessageRequest();
+            var request = new CreateMessageRequest
+            {
+                ParentId = message.ParentId
+            };
+
             string roomDecoded;
 
             try
@@ -184,7 +188,7 @@ namespace GlobalX.ChatBots.WebexTeams.Services
                     parts.AddRange(ParseMessagePart(childNode));
                 }
             }
-            
+
             return new[] { ParseSingleMessagePart(node) };
         }
 


### PR DESCRIPTION
Fixes #11 
Reply to messages inline using the parentId if that is provided.
If a parentId is provided that is itself a child comment—and cannot be replied to in Webex—reply instead to the parentId of that comment.