### PR TITLE
fix(message-handler): resend to root level parent as expected

### DIFF
--- a/src/GlobalX.ChatBots.WebexTeams.Tests/Services/WebexTeamsMessageHandlerTest.cs
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/Services/WebexTeamsMessageHandlerTest.cs
@@ -103,7 +103,8 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.Services
         {
             _apiService.GetMessageAsync(Arg.Is("badParentId")).Returns(Task.FromResult(new WebexTeamsMessage
             {
-                Id = "goodParentId"
+                Id = "badParentId",
+                ParentId = "goodParentId"
             }));
         }
 

--- a/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageHandler.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageHandler.cs
@@ -40,8 +40,8 @@ namespace GlobalX.ChatBots.WebexTeams.Services
 
         private async Task<Models.Message> ResendMessageWithRootParentId(Message message)
         {
-            var realParent = await _apiService.GetMessageAsync(message.ParentId);
-            message.ParentId = realParent.Id;
+            var parentMessage = await _apiService.GetMessageAsync(message.ParentId);
+            message.ParentId = parentMessage.ParentId;
 
             var request = _messageParser.ParseCreateMessageRequest(message);
             var result = await _apiService.SendMessageAsync(request).ConfigureAwait(false);


### PR DESCRIPTION
The code as written was sending its second attempt to go to the same invalid parentId. This fixes that.