### PR TITLE
fix: handle messages with 2 newlines in them

### DIFF
--- a/src/GlobalX.ChatBots.WebexTeams.Tests/TestData/WebexTeamsMessageParserTestData.cs
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/TestData/WebexTeamsMessageParserTestData.cs
@@ -386,6 +386,66 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.TestData
                     RoomType = RoomType.Group
                 }
             };
+
+            // double newlines
+            yield return new object[]
+            {
+                new WebexTeamsMessage
+                {
+                    Id = "messageId",
+                    RoomId = "roomId",
+                    RoomType = "group",
+                    Text = "TestBot All test things\n\nand more things.",
+                    PersonId = "senderId",
+                    PersonEmail = "sender.email@test.com",
+                    Html = "<p><spark-mention data-object-type=\"person\" data-object-id=\"testBotId\">TestBot</spark-mention> <spark-mention data-object-type=\"groupMention\" data-group-type=\"all\">All</spark-mention> test things</p><p>and more things.</p>",
+                    MentionedPeople = new[]{ "testBotId" },
+                    MentionedGroups = new []{ "all" },
+                    Created = new DateTime(2019, 7, 8, 22, 55, 52)
+                },
+                new GlobalXMessage
+                {
+                    Created = new DateTime(2019, 7, 8, 22, 55, 52),
+                    Text = "TestBot All test things\n\nand more things.",
+                    MessageParts = new[]
+                    {
+                        new MessagePart
+                        {
+                            MessageType = MessageType.PersonMention,
+                            Text = "TestBot",
+                            UserId = "testBotId"
+                        },
+                        new MessagePart
+                        {
+                            MessageType = MessageType.Text,
+                            Text = " "
+                        },
+                        new MessagePart
+                        {
+                            MessageType = MessageType.GroupMention,
+                            Text = "All",
+                            UserId = "all"
+                        },
+                        new MessagePart
+                        {
+                            MessageType = MessageType.Text,
+                            Text = " test things",
+                        },
+                        new MessagePart
+                        {
+                            MessageType = MessageType.Text,
+                            Text = "\n\n"
+                        },
+                        new MessagePart
+                        {
+                            MessageType = MessageType.Text,
+                            Text = "and more things."
+                        }
+                    },
+                    RoomId = "roomId",
+                    RoomType = RoomType.Group
+                }
+            };
         }
 
         public static IEnumerable<object[]> UnsuccessfulParseMessageTestData()

--- a/src/GlobalX.ChatBots.WebexTeams.Tests/TestData/WebexTeamsMessageParserTestData.cs
+++ b/src/GlobalX.ChatBots.WebexTeams.Tests/TestData/WebexTeamsMessageParserTestData.cs
@@ -395,10 +395,10 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.TestData
                     Id = "messageId",
                     RoomId = "roomId",
                     RoomType = "group",
-                    Text = "TestBot All test things\n\nand more things.",
+                    Text = "TestBot All test things\n\nand more\nthings.",
                     PersonId = "senderId",
                     PersonEmail = "sender.email@test.com",
-                    Html = "<p><spark-mention data-object-type=\"person\" data-object-id=\"testBotId\">TestBot</spark-mention> <spark-mention data-object-type=\"groupMention\" data-group-type=\"all\">All</spark-mention> test things</p><p>and more things.</p>",
+                    Html = "<p><spark-mention data-object-type=\"person\" data-object-id=\"testBotId\">TestBot</spark-mention> <spark-mention data-object-type=\"groupMention\" data-group-type=\"all\">All</spark-mention> test things</p><p>and more<br/>things.</p>",
                     MentionedPeople = new[]{ "testBotId" },
                     MentionedGroups = new []{ "all" },
                     Created = new DateTime(2019, 7, 8, 22, 55, 52)
@@ -406,7 +406,7 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.TestData
                 new GlobalXMessage
                 {
                     Created = new DateTime(2019, 7, 8, 22, 55, 52),
-                    Text = "TestBot All test things\n\nand more things.",
+                    Text = "TestBot All test things\n\nand more\nthings.",
                     MessageParts = new[]
                     {
                         new MessagePart
@@ -439,7 +439,17 @@ namespace GlobalX.ChatBots.WebexTeams.Tests.TestData
                         new MessagePart
                         {
                             MessageType = MessageType.Text,
-                            Text = "and more things."
+                            Text = "and more"
+                        },
+                        new MessagePart
+                        {
+                            MessageType = MessageType.Text,
+                            Text = "\n"
+                        },
+                        new MessagePart
+                        {
+                            MessageType = MessageType.Text,
+                            Text = "things."
                         }
                     },
                     RoomId = "roomId",

--- a/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageParser.cs
+++ b/src/GlobalX.ChatBots.WebexTeams/Services/WebexTeamsMessageParser.cs
@@ -169,7 +169,7 @@ namespace GlobalX.ChatBots.WebexTeams.Services
                 return ParseParagraphPart(node);
             }
 
-            string[] allowedChildNodes = { "code", "ol", "ul", "li", "b", "strong", "i", "em", "a", "spark-mention" };
+            string[] allowedChildNodes = { "code", "ol", "ul", "li", "b", "strong", "i", "em", "a", "spark-mention", "br" };
 
             if (node.ChildNodes.OfType<XmlElement>().Any(x => !allowedChildNodes.Contains(x.Name)))
             {
@@ -243,7 +243,7 @@ namespace GlobalX.ChatBots.WebexTeams.Services
                 part.MessageType = MessageType.Text;
             }
 
-            part.Text = node.InnerText;
+            part.Text = node.Name == "br" ? "\n" : node.InnerText;
             return part;
         }
 


### PR DESCRIPTION
messages with 2 newlines result in an extra `<p>` tag at the top level. Added some code to fix this and squashed some bugs along the way.